### PR TITLE
Make getSchedule to return full schedule, not only enables status

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,44 @@ Returns the scheduling state of the robot.
 
 * `callback` - `function(error, schedule)`
   * `error` null if no error occurred
-  * `schedule` boolean - true if scheduling is enabled
+  * `schedule` ```object```
+    * example:
+ ```Javascript
+var schedule = {
+    type:1,
+    enabled:true,
+    events:[
+        {
+            day:1,
+            startTime:"08:30"
+        },
+        {
+            day:2,
+            startTime:"08:30"
+        },
+        {
+            day:3,
+            startTime:"08:30"
+        },
+        {
+            day:4,
+            startTime:"08:30"
+        },
+        {
+            day:5,
+            startTime:"08:30"
+        },
+        {
+            day:6,
+            startTime:"11:30"
+        },
+        {
+            day:0,
+            startTime:"11:30"
+        }
+    ]
+}
+```
 
 -------------------------------------------------------
 <a name="enableSchedule"></a>

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -82,7 +82,7 @@ Robot.prototype.getSchedule = function getSchedule(callback) {
             if (error) {
                 callback(error, result);
             } else if (result && 'data' in result && 'enabled' in result.data) {
-                callback(null, result.data.enabled);
+                callback(null, result.data);
             } else {
                 callback(result && 'message' in result ? result.message : 'failed', result);
             }


### PR DESCRIPTION
Changes to be committed:
	modified:   lib/robot.js

I want to see the real chedule, not only status enable.
Result is, in my case:
```
schedule: {"type":1,"enabled":true,"events":[{"day":1,"startTime":"08:30"},{"day":2,"startTime":"08:30"},{"day":3,"startTime":"08:30"},{"day":4,"s
tartTime":"08:30"},{"day":5,"startTime":"08:30"},{"day":6,"startTime":"11:30"},{"day":0,"startTime":"11:30"}]}
```