### PR TITLE
Prevent request from catching exceptions in callback

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -26,13 +26,19 @@ function request(url, payload, method, headers, callback) {
         }
     }
 
+    let res, err;
+    
     axios(options)
     .then(function (response) {
-        if (typeof callback === 'function') callback(undefined, response.data);
+        res = response.data;
     })
     .catch(function (error) {
-        if (typeof callback === 'function') callback(error, undefined);
+        err = error;
     })
+    .finally(function () {
+        // Callback needs to be called in finally block, see: https://github.com/Pmant/node-botvac/issues/15
+        if (typeof callback === 'function') callback(err, res);
+    });
 }
 
 exports.request = request;


### PR DESCRIPTION
This moves the callback to the finally block. Thereby the catch block for the axios request only catches exceptions for the request itself and will no longer catch exceptions from within the callback.

Resolves #15 