### PR TITLE
Enable possibility to get full schedule object in getSchedule, with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,16 @@ var state = {
 
 -------------------------------------------------------
 <a name="getSchedule"></a>
-### robot.getSchedule([callback])
+### robot.getSchedule([callback],[getfull])
 
 Returns the scheduling state of the robot.
 
 * `callback` - `function(error, schedule)`
-  * `error` null if no error occurred
-  * `schedule` ```object```
-    * example:
+  * `error` ```null``` if no error occurred
+  * `schedule` depend of getFull
+    * ```boolean``` (when `getFull` is `undefined` or `false`) true if scheduling is enabled 
+    * ```object``` (when `getFull` is `true`) full schedule description object
+        * example:
  ```Javascript
 var schedule = {
     type:1,
@@ -191,6 +193,7 @@ var schedule = {
     ]
 }
 ```
+* `getFull` - boolean, to return the full schedule object, not only it status
 
 -------------------------------------------------------
 <a name="enableSchedule"></a>

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ var state = {
 
 -------------------------------------------------------
 <a name="getSchedule"></a>
-### robot.getSchedule([callback],[getfull])
+### robot.getSchedule([callback],[getFull])
 
 Returns the scheduling state of the robot.
 

--- a/README.md
+++ b/README.md
@@ -147,15 +147,15 @@ var state = {
 
 -------------------------------------------------------
 <a name="getSchedule"></a>
-### robot.getSchedule([callback],[getFull])
+### robot.getSchedule([callback],[detailed])
 
 Returns the scheduling state of the robot.
 
 * `callback` - `function(error, schedule)`
   * `error` ```null``` if no error occurred
-  * `schedule` depend of getFull
-    * ```boolean``` (when `getFull` is `undefined` or `false`) true if scheduling is enabled 
-    * ```object``` (when `getFull` is `true`) full schedule description object
+  * `schedule` depend on `detailed`
+    * ```boolean``` (when `detailed` is `undefined` or `false`) true if scheduling is enabled 
+    * ```object``` (when `detailed` is `true`) full schedule description object
         * example:
  ```Javascript
 var schedule = {
@@ -193,7 +193,7 @@ var schedule = {
     ]
 }
 ```
-* `getFull` - boolean, to return the full schedule object, not only it status
+* `detailed` - boolean, to return the full schedule object, not only it status
 
 -------------------------------------------------------
 <a name="enableSchedule"></a>

--- a/README.md
+++ b/README.md
@@ -153,7 +153,44 @@ Returns the scheduling state of the robot.
 
 * `callback` - `function(error, schedule)`
   * `error` null if no error occurred
-  * `schedule` boolean - true if scheduling is enabled
+  * `schedule` ```object```
+    * example:
+ ```Javascript
+var schedule = {
+    type:1,
+    enabled:true,
+    events:[
+        {
+            day:1,
+            startTime:"08:30"
+        },
+        {
+            day:2,
+            startTime:"08:30"
+        },
+        {
+            day:3,
+            startTime:"08:30"
+        },
+        {
+            day:4,
+            startTime:"08:30"
+        },
+        {
+            day:5,
+            startTime:"08:30"
+        },
+        {
+            day:6,
+            startTime:"11:30"
+        },
+        {
+            day:0,
+            startTime:"11:30"
+        }
+    ]
+}
+```
 
 -------------------------------------------------------
 <a name="enableSchedule"></a>

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -82,7 +82,7 @@ Robot.prototype.getSchedule = function getSchedule(callback) {
             if (error) {
                 callback(error, result);
             } else if (result && 'data' in result && 'enabled' in result.data) {
-                callback(null, result.data.enabled);
+                callback(null, result.data);
             } else {
                 callback(result && 'message' in result ? result.message : 'failed', result);
             }

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -76,12 +76,12 @@ Robot.prototype.getState = function getState(callback) {
     }).bind(this));
 };
 
-Robot.prototype.getSchedule = function getSchedule(callback, getFull) {
+Robot.prototype.getSchedule = function getSchedule(callback, detailed) {
     doAction(this, 'getSchedule', null, function (error, result) {
         if (typeof callback === 'function') {
             if (error) {
                 callback(error, result);
-            } else if (result && 'data' in result && (getFull !== undefined) && getFull ) {
+            } else if (result && 'data' in result && (detailed !== undefined) && detailed ) {
                 callback(null, result.data);
             } else if (result && 'data' in result && 'enabled' in result.data) {
                 callback(null, result.data.enabled);

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -76,13 +76,15 @@ Robot.prototype.getState = function getState(callback) {
     }).bind(this));
 };
 
-Robot.prototype.getSchedule = function getSchedule(callback) {
+Robot.prototype.getSchedule = function getSchedule(callback, getFull) {
     doAction(this, 'getSchedule', null, function (error, result) {
         if (typeof callback === 'function') {
             if (error) {
                 callback(error, result);
-            } else if (result && 'data' in result && 'enabled' in result.data) {
+            } else if (result && 'data' in result && (getFull !== undefined) && getFull ) {
                 callback(null, result.data);
+            } else if (result && 'data' in result && 'enabled' in result.data) {
+                callback(null, result.data.enabled);
             } else {
                 callback(result && 'message' in result ? result.message : 'failed', result);
             }


### PR DESCRIPTION
Added new parameter to this function getFull
- if `undefined` or `false` - the `schedule` still return the status, enabled or not;
- if  `true` - will return the full object, with startTime per week day and mode (if available).