### PR TITLE
0.4.2 schedule write

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -110,21 +110,21 @@ Robot.prototype.setSchedule = function setSchedule(schedule, callback) {
     else if (!this.availableServices.hasOwnPropery('schedule')) {
         error = 'Schedule is not suported by robot!';
     }
-    else if {!schedule.hasOwnPropery('type') ||  (! Number.isInteger(schedule.type)) || (schedule.type !== 1)) {
+    else if (!schedule.hasOwnPropery('type') ||  (! Number.isInteger(schedule.type)) || (schedule.type !== 1)) {
         error = 'Mandatory property type is missed or mailformed!';
     }
-    else if {!schedule.hasOwnPropery('events') || (!Array.isArray(schedule.events)) || (!schedule.events.length) || (schedule.events.length > 7) {
+    else if (!schedule.hasOwnPropery('events') || (!Array.isArray(schedule.events)) || (!schedule.events.length) || (schedule.events.length > 7)) {
         error = 'Mandatory property events is missed or mailformed!';
     }
     else if (! schedule.events.every(function scheduleValidate (event) {
         let eventLength = Object.keys(event).length;
         //check maximum possible fields amount per type of schedule
         if (((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
-        || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4)) return false;
+        || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4))) return false;
         //propery day is mandatory and has to be in between 0 and 6. The day of the week. 0 Sunday 1 Monday 2 Tuesday 3 Wednesday 4 Thursday 5 Friday 6 Saturday
         if ((! event.hasOwnPropery('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)) return false;
         //property startTime is mandatory and has to be in 'HH:MM' format
-        if ((! event.hasOwnPropery('startTime')) || ( typeof event.startTime !== 'string')) || ( ! event.startTime ) || (! timeValidator.test(event.startTime)) return false;
+        if ((! event.hasOwnPropery('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))) return false;
         //property mode is not available on 'minimal-1' schedule type
         if ((this.availableServices.schedule === 'minimal-1') && (event.hasOwnPropery('mode'))) return false;
         //but is required for basic-1 and basic-2

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -100,6 +100,65 @@ Robot.prototype.getSchedule = function getSchedule(detailed, callback) {
     });
 };
 
+
+Robot.prototype.getSchedule = function setSchedule(schedule, callback) {
+    let error = '';
+    let  timeValidator = re=/^0[0-9]|1[0-9]|2[0-3]:[0-5][0-9]$/;
+    if ((schedule === undefined) || (schedule === null) || (typeof schedule !== 'object') || (!Object.keys(schedule).length)) {
+        error = 'Wrong type of schedule object!';
+    }
+    else if (!this.availableServices.hasOwnPropery('schedule')) {
+        error = 'Schedule is not suported by robot!';
+    }
+    else if {!schedule.hasOwnPropery('type') ||  (! Number.isInteger(schedule.type)) || (schedule.type !== 1)) {
+        error = 'Mandatory property type is missed or mailformed!';
+    }
+    else if {!schedule.hasOwnPropery('events') || (!Array.isArray(schedule.events)) || (!schedule.events.length) || (schedule.events.length > 7) {
+        error = 'Mandatory property events is missed or mailformed!';
+    }
+    else if (! schedule.events.every(function scheduleValidate (event) {
+        let eventLength = Object.keys(event).length;
+        //check maximum possible fields amount per type of schedule
+        if (((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
+        || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4)) return false;
+        //propery day is mandatory and has to be in between 0 and 6. The day of the week. 0 Sunday 1 Monday 2 Tuesday 3 Wednesday 4 Thursday 5 Friday 6 Saturday
+        if ((! event.hasOwnPropery('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)) return false;
+        //property startTime is mandatory and has to be in 'HH:MM' format
+        if ((! event.hasOwnPropery('startTime')) || ( typeof event.startTime !== 'string')) || ( ! event.startTime ) || (! timeValidator.test(event.startTime)) return false;
+        //property mode is not available on 'minimal-1' schedule type
+        if ((this.availableServices.schedule === 'minimal-1') && (event.hasOwnPropery('mode'))) return false;
+        //but is required for basic-1 and basic-2
+        if (((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnPropery('mode'))) return false;
+        //mode - the cleaning mode. 1 Eco 2 Normal.
+        if ((event.hasOwnPropery('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))) return false;
+        //initially not supported
+        if (((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnPropery('boundaryId'))) return false;
+        if  (event.hasOwnPropery('boundaryId') && event.boundaryId ) return false;
+        }, this)) {
+        error = 'Wrong structure of the schedule! Please check!';
+    }
+    if (error) {
+        if (typeof callback === 'function') {
+            callback(error, schedule);
+        }
+        return;
+    }
+    doAction(this, 'setSchedule', schedule, function (error, result) {
+        if (typeof callback === 'function') {
+            if (error) {
+                callback(error, result);
+            } else if (result && 'data' in result && (detailed !== undefined) && detailed ) {
+                callback(null, result.data);
+            } else if (result && 'data' in result && 'enabled' in result.data) {
+                callback(null, result.data.enabled);
+            } else {
+                callback(result && 'message' in result ? result.message : 'failed', result);
+            }
+        }
+    });
+};
+
+
 Robot.prototype.enableSchedule = function enableSchedule(callback) {
     doAction(this, 'enableSchedule', null, function (error, result) {
         if (typeof callback === 'function') {

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -101,41 +101,68 @@ Robot.prototype.getSchedule = function getSchedule(detailed, callback) {
 };
 
 
+let  timeValidator = new RegExp(/^(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$/);
+
 Robot.prototype.setSchedule = function setSchedule(schedule, callback) {
     let error = '';
-    let  timeValidator = re=/^0[0-9]|1[0-9]|2[0-3]:[0-5][0-9]$/;
+    let debug = '';
     if ((schedule === undefined) || (schedule === null) || (typeof schedule !== 'object') || (!Object.keys(schedule).length)) {
         error = 'Wrong type of schedule object!';
     }
-    else if (!this.availableServices.hasOwnPropery('schedule')) {
+    else if (!this.availableServices.hasOwnProperty('schedule')) {
         error = 'Schedule is not suported by robot!';
     }
-    else if (!schedule.hasOwnPropery('type') ||  (! Number.isInteger(schedule.type)) || (schedule.type !== 1)) {
+    else if (!schedule.hasOwnProperty('type') ||  (! Number.isInteger(schedule.type)) || (schedule.type !== 1)) {
         error = 'Mandatory property type is missed or mailformed!';
     }
-    else if (!schedule.hasOwnPropery('events') || (!Array.isArray(schedule.events)) || (!schedule.events.length) || (schedule.events.length > 7)) {
+    else if (!schedule.hasOwnProperty('events') || (!Array.isArray(schedule.events)) || (!schedule.events.length) || (schedule.events.length > 7)) {
         error = 'Mandatory property events is missed or mailformed!';
     }
     else if (! schedule.events.every(function scheduleValidate (event) {
         let eventLength = Object.keys(event).length;
         //check maximum possible fields amount per type of schedule
+        debug += "\n" + '1 ' + JSON.stringify((((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
+        || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4)))) ;
+
         if (((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
         || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4))) return false;
+
         //propery day is mandatory and has to be in between 0 and 6. The day of the week. 0 Sunday 1 Monday 2 Tuesday 3 Wednesday 4 Thursday 5 Friday 6 Saturday
-        if ((! event.hasOwnPropery('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)) return false;
+        debug += "\n" + ' 2 ' + JSON.stringify(((! event.hasOwnProperty('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)));
+
+        if ((! event.hasOwnProperty('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)) return false;
+
         //property startTime is mandatory and has to be in 'HH:MM' format
-        if ((! event.hasOwnPropery('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))) return false;
+        debug += "\n" + ' 3 ' + JSON.stringify(((! event.hasOwnProperty('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))));
+
+        if ((! event.hasOwnProperty('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))) return false;
+
         //property mode is not available on 'minimal-1' schedule type
-        if ((this.availableServices.schedule === 'minimal-1') && (event.hasOwnPropery('mode'))) return false;
+        debug += "\n" + ' 4 ' + JSON.stringify(((this.availableServices.schedule === 'minimal-1') && (event.hasOwnProperty('mode'))));
+
+        if ((this.availableServices.schedule === 'minimal-1') && (event.hasOwnProperty('mode'))) return false;
+
         //but is required for basic-1 and basic-2
-        if (((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnPropery('mode'))) return false;
+        debug += "\n" + ' 5 ' + JSON.stringify((((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnProperty('mode'))));
+
+        if (((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnProperty('mode'))) return false;
+
         //mode - the cleaning mode. 1 Eco 2 Normal.
-        if ((event.hasOwnPropery('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))) return false;
-        //initially not supported
-        if (((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnPropery('boundaryId'))) return false;
-        if  (event.hasOwnPropery('boundaryId') && event.boundaryId ) return false;
+        debug += "\n" + ' 6 ' + JSON.stringify(((event.hasOwnProperty('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))));
+
+        if ((event.hasOwnProperty('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))) return false;
+        //initially setting boundaries is not supported
+        debug += "\n" + ' 7 ' + JSON.stringify((((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnProperty('boundaryId'))));
+        if (((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnProperty('boundaryId'))) return false;
+
+        debug += "\n" + ' 8 ' + JSON.stringify();
+        if  (event.hasOwnProperty('boundaryId') && event.boundaryId ) return false;
+
+        debug += "\n" + ' 9 ' + JSON.stringify((event.hasOwnProperty('boundaryId') && event.boundaryId ));
+
+        return true;
         }, this)) {
-        error = 'Wrong structure of the schedule! Please check!';
+        error = 'Wrong structure of the schedule! Please check!' + ' ' +  debug;
     }
     if (error) {
         if (typeof callback === 'function') {
@@ -147,10 +174,8 @@ Robot.prototype.setSchedule = function setSchedule(schedule, callback) {
         if (typeof callback === 'function') {
             if (error) {
                 callback(error, result);
-            } else if (result && 'data' in result && (detailed !== undefined) && detailed ) {
+            } else if (result && 'data' in result ) {
                 callback(null, result.data);
-            } else if (result && 'data' in result && 'enabled' in result.data) {
-                callback(null, result.data.enabled);
             } else {
                 callback(result && 'message' in result ? result.message : 'failed', result);
             }

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -101,7 +101,7 @@ Robot.prototype.getSchedule = function getSchedule(detailed, callback) {
 };
 
 
-Robot.prototype.getSchedule = function setSchedule(schedule, callback) {
+Robot.prototype.setSchedule = function setSchedule(schedule, callback) {
     let error = '';
     let  timeValidator = re=/^0[0-9]|1[0-9]|2[0-3]:[0-5][0-9]$/;
     if ((schedule === undefined) || (schedule === null) || (typeof schedule !== 'object') || (!Object.keys(schedule).length)) {

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -115,54 +115,64 @@ Robot.prototype.setSchedule = function setSchedule(schedule, callback) {
     else if (!schedule.hasOwnProperty('type') ||  (! Number.isInteger(schedule.type)) || (schedule.type !== 1)) {
         error = 'Mandatory property type is missed or mailformed!';
     }
-    else if (!schedule.hasOwnProperty('events') || (!Array.isArray(schedule.events)) || (!schedule.events.length) || (schedule.events.length > 7)) {
+    else if (!schedule.hasOwnProperty('events') || (!Array.isArray(schedule.events)) || (schedule.events.length > 7)) {
         error = 'Mandatory property events is missed or mailformed!';
     }
     else if (! schedule.events.every(function scheduleValidate (event) {
-        let eventLength = Object.keys(event).length;
-        //check maximum possible fields amount per type of schedule
-        debug += "\n" + '1 ' + JSON.stringify((((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
-        || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4)))) ;
+            let eventLength = Object.keys(event).length;
+            //console.log() doesn't work under ioBroker, thats why such construction is used
 
-        if (((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
-        || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4))) return false;
+            //check maximum possible fields amount per type of schedule
+            debug += "\n" + '1 ' + JSON.stringify((((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
+            || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4)))) ;
 
-        //propery day is mandatory and has to be in between 0 and 6. The day of the week. 0 Sunday 1 Monday 2 Tuesday 3 Wednesday 4 Thursday 5 Friday 6 Saturday
-        debug += "\n" + ' 2 ' + JSON.stringify(((! event.hasOwnProperty('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)));
+            if (((this.availableServices.schedule === 'minimal-1') && (eventLength > 2)) || ((this.availableServices.schedule === 'basic-1') && (eventLength > 3))
+            || ((this.availableServices.schedule === 'basic-2') && (eventLength > 4))) return false;
 
-        if ((! event.hasOwnProperty('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)) return false;
 
-        //property startTime is mandatory and has to be in 'HH:MM' format
-        debug += "\n" + ' 3 ' + JSON.stringify(((! event.hasOwnProperty('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))));
+            //propery day is mandatory and has to be in between 0 and 6. The day of the week. 0 Sunday 1 Monday 2 Tuesday 3 Wednesday 4 Thursday 5 Friday 6 Saturday
+            debug += "\n" + ' 2 ' + JSON.stringify(((! event.hasOwnProperty('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)));
 
-        if ((! event.hasOwnProperty('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))) return false;
+            if ((! event.hasOwnProperty('day')) || (! Number.isInteger(event.day)) || ( event.day < 0 ) || ( event.day > 6)) return false;
 
-        //property mode is not available on 'minimal-1' schedule type
-        debug += "\n" + ' 4 ' + JSON.stringify(((this.availableServices.schedule === 'minimal-1') && (event.hasOwnProperty('mode'))));
 
-        if ((this.availableServices.schedule === 'minimal-1') && (event.hasOwnProperty('mode'))) return false;
+            //property startTime is mandatory and has to be in 'HH:MM' format
+            debug += "\n" + ' 3 ' + JSON.stringify(((! event.hasOwnProperty('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))));
 
-        //but is required for basic-1 and basic-2
-        debug += "\n" + ' 5 ' + JSON.stringify((((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnProperty('mode'))));
+            if ((! event.hasOwnProperty('startTime')) || ( typeof event.startTime !== 'string') || ( ! event.startTime ) || (! timeValidator.test(event.startTime))) return false;
 
-        if (((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnProperty('mode'))) return false;
 
-        //mode - the cleaning mode. 1 Eco 2 Normal.
-        debug += "\n" + ' 6 ' + JSON.stringify(((event.hasOwnProperty('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))));
+            //property mode is not available on 'minimal-1' schedule type
+            debug += "\n" + ' 4 ' + JSON.stringify(((this.availableServices.schedule === 'minimal-1') && (event.hasOwnProperty('mode'))));
 
-        if ((event.hasOwnProperty('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))) return false;
-        //initially setting boundaries is not supported
-        debug += "\n" + ' 7 ' + JSON.stringify((((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnProperty('boundaryId'))));
-        if (((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnProperty('boundaryId'))) return false;
+            if ((this.availableServices.schedule === 'minimal-1') && (event.hasOwnProperty('mode'))) return false;
 
-        debug += "\n" + ' 8 ' + JSON.stringify();
-        if  (event.hasOwnProperty('boundaryId') && event.boundaryId ) return false;
 
-        debug += "\n" + ' 9 ' + JSON.stringify((event.hasOwnProperty('boundaryId') && event.boundaryId ));
+            //but is required for basic-1 and basic-2
+            debug += "\n" + ' 5 ' + JSON.stringify((((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnProperty('mode'))));
 
-        return true;
-        }, this)) {
-        error = 'Wrong structure of the schedule! Please check!' + ' ' +  debug;
+            if (((this.availableServices.schedule === 'basic-1') || (this.availableServices.schedule === 'basic-1')) && (!event.hasOwnProperty('mode'))) return false;
+
+            //mode - the cleaning mode. 1 Eco 2 Normal.
+            debug += "\n" + ' 6 ' + JSON.stringify(((event.hasOwnProperty('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))));
+
+            if ((event.hasOwnProperty('mode')) && ((! Number.isInteger(event.mode)) || ( event.mode < 1 ) || ( event.mode > 2))) return false;
+
+
+            //initially setting boundaries is not supported
+
+            debug += "\n" + ' 7 ' + JSON.stringify((((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnProperty('boundaryId'))));
+
+            if (((this.availableServices.schedule === 'minimal-1') || (this.availableServices.schedule === 'basic-1')) && (event.hasOwnProperty('boundaryId'))) return false;
+
+            // to process boundaries from ioBroker, as it not editable, and will be reused from original
+            //debug += "\n" + ' 8 ' + JSON.stringify((event.hasOwnProperty('boundaryId') && event.boundaryId ));
+            //if  (event.hasOwnProperty('boundaryId') && event.boundaryId ) return false;
+
+            return true; 
+        }, this)
+        ) {
+            error = 'Wrong structure of the schedule! Please check!' + ' ' +  debug;
     }
     if (error) {
         if (typeof callback === 'function') {

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -10,6 +10,7 @@ function Robot(name, serial, secret, token) {
     this._token = token;
 
     //updated when getState() is called
+    this.availableServices = null;
     this.isBinFull = null;
     this.isCharging = null;
     this.isDocked = null;
@@ -41,6 +42,7 @@ Robot.prototype.getState = function getState(callback) {
             } else if (result && 'message' in result) {
                 callback(result.message, result);
             } else {
+                this.availableServices = result.availableServices;
                 this.isBinFull = result.alert == "dustbin_full";
                 this.isCharging = result.details.isCharging;
                 this.isDocked = result.details.isDocked;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-botvac",
-  "version": "0.4.2",
+  "version": "0.4.2-schedule-write",
   "description": "Neato Botvac API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi.

there is a new function setSchedule, it is processed schedule as it required by [neato docs](https://developers.neatorobotics.com/api/robot-remote-protocol/schedule).

It has validation for all properties of schedule, except boundaryId's.
Currently it checked to work with only 'minimal-1' type of schedule, as it the highest version in my BotVac D5.
It is now working under ioBroker botvac driver, with my modification, and pointed to dev version of node-botvac.

Still a lot of debug, for the further tests with other versions of robots.
As I faced with impossibility to see the console.log output under ioBroker - it's has a strange construction for debug.
Any help with console.log under ioBroker is appreciated.

Main point for using out of ioBroker - you have every time to send a full schedule, not only for the modified/new day of week ...
Currently in broker is possible to replace and clear schedule for any type of schedule, but new day's can be added only for the `minimal-1`.